### PR TITLE
feat(ext-kupo): add support for node affinity

### DIFF
--- a/bootstrap/cell/main.tf
+++ b/bootstrap/cell/main.tf
@@ -30,11 +30,11 @@ module "kupo_instances" {
 
   resources = coalesce(each.value.resources, {
     limits = {
-      cpu    = "1",
+      cpu    = "1"
       memory = "1Gi"
     }
     requests = {
-      cpu    = "500m",
+      cpu    = "500m"
       memory = "1Gi"
     }
   })
@@ -58,4 +58,8 @@ module "kupo_instances" {
       value    = "consistent"
     }
   ])
+  node_affinity = coalesce(each.value.node_affinity, {
+    required_during_scheduling_ignored_during_execution  = {}
+    preferred_during_scheduling_ignored_during_execution = []
+  })
 }

--- a/bootstrap/cell/variables.tf
+++ b/bootstrap/cell/variables.tf
@@ -49,5 +49,43 @@ variable "instances" {
       operator = string
       value    = optional(string)
     })))
+    node_affinity = optional(object({
+      required_during_scheduling_ignored_during_execution = optional(
+        object({
+          node_selector_term = optional(
+            list(object({
+              match_expressions = optional(
+                list(object({
+                  key      = string
+                  operator = string
+                  values   = list(string)
+                })), []
+              )
+            })), []
+          )
+        }), {}
+      )
+      preferred_during_scheduling_ignored_during_execution = optional(
+        list(object({
+          weight = number
+          preference = object({
+            match_expressions = optional(
+              list(object({
+                key      = string
+                operator = string
+                values   = list(string)
+              })), []
+            )
+            match_fields = optional(
+              list(object({
+                key      = string
+                operator = string
+                values   = list(string)
+              })), []
+            )
+          })
+        })), []
+      )
+    }))
   }))
 }

--- a/bootstrap/instance/main.tf
+++ b/bootstrap/instance/main.tf
@@ -82,3 +82,45 @@ variable "tolerations" {
     }
   ]
 }
+
+variable "node_affinity" {
+  type = object({
+    required_during_scheduling_ignored_during_execution = optional(
+      object({
+        node_selector_term = optional(
+          list(object({
+            match_expressions = optional(
+              list(object({
+                key      = string
+                operator = string
+                values   = list(string)
+              })), []
+            )
+          })), []
+        )
+      }), {}
+    )
+    preferred_during_scheduling_ignored_during_execution = optional(
+      list(object({
+        weight = number
+        preference = object({
+          match_expressions = optional(
+            list(object({
+              key      = string
+              operator = string
+              values   = list(string)
+            })), []
+          )
+          match_fields = optional(
+            list(object({
+              key      = string
+              operator = string
+              values   = list(string)
+            })), []
+          )
+        })
+      })), []
+    )
+  })
+  default = {}
+}

--- a/bootstrap/instance/sts.tf
+++ b/bootstrap/instance/sts.tf
@@ -53,6 +53,75 @@ resource "kubernetes_stateful_set_v1" "kupo" {
           fs_group = 1000
         }
 
+        dynamic "affinity" {
+          for_each = (
+            var.node_affinity != null &&
+            (
+              try(length(var.node_affinity.required_during_scheduling_ignored_during_execution.node_selector_term), 0) > 0 ||
+              try(length(var.node_affinity.preferred_during_scheduling_ignored_during_execution), 0) > 0
+            )
+          ) ? [var.node_affinity] : []
+          content {
+            node_affinity {
+              dynamic "required_during_scheduling_ignored_during_execution" {
+                for_each = (
+                  var.node_affinity.required_during_scheduling_ignored_during_execution != null &&
+                  length(var.node_affinity.required_during_scheduling_ignored_during_execution.node_selector_term) > 0
+                ) ? [var.node_affinity.required_during_scheduling_ignored_during_execution] : []
+                content {
+                  dynamic "node_selector_term" {
+                    for_each = required_during_scheduling_ignored_during_execution.value.node_selector_term
+                    content {
+                      dynamic "match_expressions" {
+                        for_each = length(node_selector_term.value.match_expressions) > 0 ? node_selector_term.value.match_expressions : []
+                        content {
+                          key      = match_expressions.value.key
+                          operator = match_expressions.value.operator
+                          values   = match_expressions.value.values
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+              dynamic "preferred_during_scheduling_ignored_during_execution" {
+                for_each = (
+                  var.node_affinity.preferred_during_scheduling_ignored_during_execution != null &&
+                  length(var.node_affinity.preferred_during_scheduling_ignored_during_execution) > 0
+                ) ? var.node_affinity.preferred_during_scheduling_ignored_during_execution : []
+                content {
+                  weight = preferred_during_scheduling_ignored_during_execution.value.weight
+
+                  dynamic "preference" {
+                    for_each = (
+                      length(preferred_during_scheduling_ignored_during_execution.value.preference.match_expressions) > 0 ||
+                      length(preferred_during_scheduling_ignored_during_execution.value.preference.match_fields) > 0
+                    ) ? [preferred_during_scheduling_ignored_during_execution.value.preference] : []
+                    content {
+                      dynamic "match_expressions" {
+                        for_each = length(preference.value.match_expressions) > 0 ? preference.value.match_expressions : []
+                        content {
+                          key      = match_expressions.value.key
+                          operator = match_expressions.value.operator
+                          values   = match_expressions.value.values
+                        }
+                      }
+                      dynamic "match_fields" {
+                        for_each = length(preference.value.match_fields) > 0 ? preference.value.match_fields : []
+                        content {
+                          key      = match_fields.value.key
+                          operator = match_fields.value.operator
+                          values   = match_fields.value.values
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+
         container {
           name              = "main"
           image             = "ghcr.io/demeter-run/ext-cardano-kupo-instance:${var.image_tag}"
@@ -126,16 +195,13 @@ resource "kubernetes_stateful_set_v1" "kupo" {
         }
 
         container {
+          name  = "socat"
+          image = "alpine/socat:latest"
           args = [
             "-d",
             "UNIX-LISTEN:/ipc/node.socket,fork,reuseaddr,unlink-early",
             "TCP:${var.n2n_endpoint}",
           ]
-
-          image = "alpine/socat:latest"
-
-          name = "socat"
-
           volume_mount {
             mount_path = "/ipc"
             name       = "cardanoipc"
@@ -167,7 +233,7 @@ resource "kubernetes_stateful_set_v1" "kupo" {
             effect   = toleration.value.effect
             key      = toleration.value.key
             operator = toleration.value.operator
-            value    = toleration.value.value
+            value    = try(toleration.value["value"], null)
           }
         }
       }

--- a/bootstrap/variables.tf
+++ b/bootstrap/variables.tf
@@ -233,6 +233,44 @@ variable "cells" {
         operator = string
         value    = optional(string)
       })))
+      node_affinity = optional(object({
+        required_during_scheduling_ignored_during_execution = optional(
+          object({
+            node_selector_term = optional(
+              list(object({
+                match_expressions = optional(
+                  list(object({
+                    key      = string
+                    operator = string
+                    values   = list(string)
+                  })), []
+                )
+              })), []
+            )
+          }), {}
+        )
+        preferred_during_scheduling_ignored_during_execution = optional(
+          list(object({
+            weight = number
+            preference = object({
+              match_expressions = optional(
+                list(object({
+                  key      = string
+                  operator = string
+                  values   = list(string)
+                })), []
+              )
+              match_fields = optional(
+                list(object({
+                  key      = string
+                  operator = string
+                  values   = list(string)
+                })), []
+              )
+            })
+          })), []
+        )
+      }))
     }))
   }))
 }


### PR DESCRIPTION
Add node_affinity as optional. The default value is {} and doesn't generate `affinity`. No terraform changes are expected in this case.

Test if node_affinity is defined.

```
          ~ template {
              ~ spec {
                    # (18 unchanged attributes hidden)

                  + affinity {
                      + node_affinity {
                          + required_during_scheduling_ignored_during_execution {
                              + node_selector_term {
                                  + match_expressions {
                                      + key      = "cloud.google.com/gke-nodepool"
                                      + operator = "In"
                                      + values   = [
                                          + "co-di-arm64-az1",
                                        ]
                                    }
                                }
                            }
                        }
                    }

                    # (10 unchanged blocks hidden)
                }

                # (1 unchanged block hidden)
            }
```
Applied

```
    spec:
      affinity:
        nodeAffinity:
          requiredDuringSchedulingIgnoredDuringExecution:
            nodeSelectorTerms:
            - matchExpressions:
              - key: cloud.google.com/gke-nodepool
                operator: In
                values:
                - co-di-arm64-az1
                
```